### PR TITLE
Implement parameter incorporation into fit object before cleanup

### DIFF
--- a/R/sccomp_estimate.R
+++ b/R/sccomp_estimate.R
@@ -706,6 +706,14 @@ sccomp_estimate.data.frame <- function(.data,
   
   # Auto-cleanup draw files if requested
   if (cleanup_draw_files) {
+    # Incorporate all parameters into fit object BEFORE deleting CSV files
+    # This ensures parameters are cached in memory and remain accessible after cleanup
+    fit_obj <- attr(res, "fit")
+    incorporate_parameters_into_fit_object(fit_obj)
+    
+    # Update the fit attribute with the modified fit object
+    attr(res, "fit") <- fit_obj
+    
     if (dir.exists(output_directory)) {
       files_deleted <- list.files(output_directory, pattern = "\\.csv$", full.names = TRUE)
       if (length(files_deleted) > 0) {

--- a/tests/testthat/test-incorporate-parameters.R
+++ b/tests/testthat/test-incorporate-parameters.R
@@ -1,0 +1,121 @@
+library(dplyr)
+library(tidyr)
+library(sccomp)
+
+test_that("incorporate_parameters_into_fit_object loads all parameters", {
+  skip_cmdstan()
+  
+  # Load test data
+  data("counts_obj")
+  
+  # Create a test output directory
+  test_output_dir <- tempfile("sccomp_test_draws_")
+  dir.create(test_output_dir)
+  
+  # Run sccomp_estimate with cleanup_draw_files = FALSE to keep CSV files temporarily
+  result <- counts_obj |>
+    sccomp_estimate(
+      formula_composition = ~ type,
+      formula_variability = ~ 1,
+      sample = "sample",
+      cell_group = "cell_group",
+      abundance = "count",
+      cores = 1,
+      inference_method = "pathfinder",
+      max_sampling_iterations = 500,
+      verbose = FALSE,
+      output_directory = test_output_dir,
+      cleanup_draw_files = FALSE  # Keep files to test manual incorporation
+    )
+  
+  # Get the fit object
+  fit <- attr(result, "fit")
+  
+  # Check that CSV files exist
+  csv_files <- list.files(test_output_dir, pattern = "\\.csv$", full.names = TRUE)
+  expect_true(length(csv_files) > 0, info = "CSV files should exist before cleanup")
+  
+  # Call the function to incorporate parameters
+  expect_no_error({
+    sccomp:::incorporate_parameters_into_fit_object(fit)
+  })
+  
+  # Verify that key parameters can be accessed after incorporation
+  expect_no_error({
+    beta_draws <- fit$draws(variables = "beta", format = "draws_df")
+  })
+  
+  expect_no_error({
+    alpha_draws <- fit$draws(variables = "alpha", format = "draws_df")
+  })
+  
+  expect_no_error({
+    prec_coeff_draws <- fit$draws(variables = "prec_coeff", format = "draws_df")
+  })
+  
+  # Now delete the CSV files to simulate cleanup
+  file.remove(csv_files)
+  
+  # Verify CSV files are gone
+  csv_files_after <- list.files(test_output_dir, pattern = "\\.csv$", full.names = TRUE)
+  expect_equal(length(csv_files_after), 0, info = "CSV files should be deleted")
+  
+  # Parameters should still be accessible because they were incorporated
+  expect_no_error({
+    beta_draws_after <- fit$draws(variables = "beta", format = "draws_df")
+  })
+  
+  expect_no_error({
+    alpha_draws_after <- fit$draws(variables = "alpha", format = "draws_df")
+  })
+  
+  # Verify the draws are the same before and after CSV deletion
+  expect_equal(beta_draws, beta_draws_after)
+  
+  # Clean up test directory
+  unlink(test_output_dir, recursive = TRUE)
+})
+
+test_that("incorporate_parameters_into_fit_object handles models without random effects", {
+  skip_cmdstan()
+  
+  data("counts_obj")
+  
+  test_output_dir <- tempfile("sccomp_test_draws_")
+  dir.create(test_output_dir)
+  
+  # Run a simple model without random effects
+  result <- counts_obj |>
+    sccomp_estimate(
+      formula_composition = ~ 1,
+      formula_variability = ~ 1,
+      sample = "sample",
+      cell_group = "cell_group",
+      abundance = "count",
+      cores = 1,
+      inference_method = "pathfinder",
+      max_sampling_iterations = 500,
+      verbose = FALSE,
+      output_directory = test_output_dir,
+      cleanup_draw_files = FALSE
+    )
+  
+  fit <- attr(result, "fit")
+  
+  # Should handle models without random effects gracefully
+  expect_no_error({
+    sccomp:::incorporate_parameters_into_fit_object(fit)
+  })
+  
+  # Basic parameters should still be accessible
+  expect_no_error({
+    fit$draws(variables = "beta", format = "draws_df")
+  })
+  
+  expect_no_error({
+    fit$draws(variables = "alpha", format = "draws_df")
+  })
+  
+  # Clean up
+  unlink(test_output_dir, recursive = TRUE)
+})

--- a/tests/testthat/test-sccomp_.R
+++ b/tests/testthat/test-sccomp_.R
@@ -330,14 +330,13 @@ test_that("multilevel multi beta binomial from Seurat with intercept and continu
       inference_method = "hmc", verbose=FALSE
     )
 
-    expect(
+    expect_true(
       "CD8 em 1" %in%
       (res |>
         filter(parameter == "continuous_covariate") |>
         arrange(desc(abs(c_effect))) |>
         slice(1:3) |>
-        pull(cell_group)),
-      TRUE
+        pull(cell_group))
     )
 
 
@@ -839,7 +838,9 @@ test_that("LOO", {
       cell_group = "cell_group", 
       inference_method = "hmc",
       cores = 1, 
-      enable_loo = TRUE, max_sampling_iterations = n_iterations, verbose = FALSE
+      enable_loo = TRUE, 
+      max_sampling_iterations = n_iterations, 
+      verbose = FALSE
     ) |> 
     expect_no_error()
   
@@ -852,7 +853,9 @@ test_that("LOO", {
       cell_group = "cell_group", 
       inference_method = "hmc",
       cores = 1, 
-      enable_loo = TRUE, max_sampling_iterations = n_iterations, verbose = FALSE
+      enable_loo = TRUE, 
+      max_sampling_iterations = n_iterations, 
+      verbose = FALSE
     ) |> 
     expect_no_error()
   


### PR DESCRIPTION
- Added `incorporate_parameters_into_fit_object` function to load all Stan model parameters into the fit object, ensuring accessibility after CSV draw files are deleted.
- Updated `sccomp_estimate.data.frame` to call this function when `cleanup_draw_files` is enabled.
- Introduced tests to verify the functionality of parameter incorporation and its handling of models with and without random effects.